### PR TITLE
Add Support to Upsert/Insert Ignore on PDB (#388)

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
@@ -190,9 +190,14 @@ public interface DatabaseEngine extends AutoCloseable {
     /**
      * Flushes the batches for all the registered entities upserting duplicated entries.
      *
+     * @implNote The default implementation of this method throws an {@link UnsupportedOperationException}
+     * for backward-compatibility reasons. If this method is supposed to be called, it must be explicitly overridden.
+     *
      * @throws DatabaseEngineException If something goes wrong while persisting data.
      */
-    void flushUpsert() throws DatabaseEngineException;
+    default void flushUpsert() throws DatabaseEngineException {
+        throw new UnsupportedOperationException("Method not implemented.");
+    }
 
     /**
      * Commits the current transaction. You should only call this method if you've previously called
@@ -397,9 +402,15 @@ public interface DatabaseEngine extends AutoCloseable {
      *
      * @param name  The entity name.
      * @param entry The entry to persist.
+     *
+     * @implNote The default implementation of this method throws an {@link UnsupportedOperationException}
+     * for backward-compatibility reasons. If this method is supposed to be called, it must be explicitly overridden.
+     *
      * @throws DatabaseEngineException If something goes wrong while persisting data.
      */
-    void addBatchUpsert(final String name, final EntityEntry entry) throws DatabaseEngineException;
+    default void addBatchUpsert(final String name, final EntityEntry entry) throws DatabaseEngineException {
+        throw new UnsupportedOperationException("Method not implemented.");
+    }
 
     /**
      * Executes the given query.


### PR DESCRIPTION
* Add Support to Upsert/Insert Ignore on PDB
- Makes the implementation of DatabaseEngine optional, so it does not break compatibility with other library clients.

---------
Co-authored-by: Victor Camargo <victor.camargo@feedzai.com>